### PR TITLE
fix tests

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-require('6to5/register')({
+require('babel/register')({
   extensions: ['.js', '.es6.js'],
   experimental: true,
 });


### PR DESCRIPTION
This PR replaces `6to5/register` with `babel/register` (fixes `Error: Cannot find module '6to5/register'`)

There's still another issue when attempting to run tests:

```
> horse@1.2.0 test /Users/ng/dev/github/horse
> ./node_modules/mocha/bin/mocha ./test/index.js

/Users/ng/dev/github/horse/node_modules/babel/node_modules/babel-core/lib/babel/transformation/file/index.js:122
        throw new Error("Deprecated option " + key + ": " + option.deprecated)
              ^
Error: Deprecated option experimental: use `--stage 0`/`{ stage: 0 }` instead
```
