### PR TITLE
updated to support co-4.0+ and koa-router-5.1+

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/reddit/horse/issues"
   },
   "dependencies": {
-    "co": "^4.4.0",
-    "koa-router": "^4.2.0"
+    "co": "^4.6.0",
+    "koa-router": "^5.1.2"
   },
   "devDependencies": {
     "babel": "^5.0.0",

--- a/src/app.es6.js
+++ b/src/app.es6.js
@@ -92,8 +92,7 @@ class App {
   error (err, ctx, app) {
     var status = err.status || 500;
     var message = err.message || 'Unkown error';
-
-    var reroute = '/' + status;
+    
     var url = '/' + status;
 
     var query = querystring.stringify({
@@ -101,14 +100,7 @@ class App {
     });
 
     url += '?' + query;
-
-    if (ctx.request.url !== url) {
-      ctx.set('Cache-Control', 'no-cache');
-      ctx.redirect(url);
-    } else {
-      // Critical failure! The error page is erroring! Abandon all hope
-      console.log(err);
-    }
+    ctx.redirect(url);
   }
 }
 

--- a/src/app.es6.js
+++ b/src/app.es6.js
@@ -43,14 +43,12 @@ class App {
         resolve();
       });
     }
-
+   ctx.route = route;
    var middleware = co.wrap(route.middleware).call(ctx).catch(ctx.onerror);
 
     return co(function * () {
       if (app.startRequest.length) {
         app.startRequest.forEach(function(f) {
-          // pre-set it for the startRequest call
-          ctx.route = route;
           return f.call(ctx, app);
         });
       }

--- a/src/app.es6.js
+++ b/src/app.es6.js
@@ -47,10 +47,9 @@ class App {
    var middleware = co.wrap(route.middleware).call(ctx).catch(ctx.onerror);
 
     return co(function * () {
+      ctx.route = route;
       if (app.startRequest.length) {
         app.startRequest.forEach(function(f) {
-          // pre-set it for the startRequest call
-          ctx.route = route;
           return f.call(ctx, app);
         });
       }

--- a/test/app.es6.js
+++ b/test/app.es6.js
@@ -99,7 +99,7 @@ describe('App', function() {
 
       sinon.stub(app, 'error');
 
-      app.router.get('/', function(req, res, next) {
+      app.router.get('/', function *(next) {
         throw 'EVERTHING IS WRONG';
       });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,7 @@
 require('babel/register')({
   extensions: ['.js', '.es6.js'],
+  ignore: false,
+  only: /.+(?:(?:\.es6\.js)|(?:.jsx))$/
 });
 
 require('./app');


### PR DESCRIPTION
This pull request updates the code with latest versions of `koa-router` which had breaking changes in its api (`match` method) and `co` which now only yields promises.
