### PR TITLE
Fix extra `bind`

### DIFF
--- a/src/app.es6.js
+++ b/src/app.es6.js
@@ -71,7 +71,7 @@ class App {
       }
 
       this.error(err, ctx, app);
-    }.bind(this));
+    });
   }
 
   registerPlugin (plugin) {


### PR DESCRIPTION
:eyeglasses: @curioussavage 

We're using an arrow function, so bind is unnecessary (and causes errors in strict es6.)
